### PR TITLE
✨ Expose ConsentManagerApi

### DIFF
--- a/src/consent-manager/container.tsx
+++ b/src/consent-manager/container.tsx
@@ -4,7 +4,7 @@ import Banner from './banner'
 import PreferenceDialog from './preference-dialog'
 import CancelDialog from './cancel-dialog'
 import { ADVERTISING_CATEGORIES, FUNCTIONAL_CATEGORIES } from './categories'
-import { Destination, CategoryPreferences, CustomCategories } from '../types'
+import { Destination, CategoryPreferences, CustomCategories, ConsentManagerApi } from '../types'
 
 const emitter = new EventEmitter()
 export function openDialog() {
@@ -40,6 +40,7 @@ interface ContainerProps {
   preferencesDialogContent: React.ReactNode
   cancelDialogTitle: React.ReactNode
   cancelDialogContent: React.ReactNode
+  showBanner?: boolean
 }
 
 function normalizeDestinations(destinations: Destination[]) {
@@ -61,10 +62,16 @@ function normalizeDestinations(destinations: Destination[]) {
   return { marketingDestinations, advertisingDestinations, functionalDestinations }
 }
 
-const Container: React.FC<ContainerProps> = props => {
+const Container: React.FC<ContainerProps> = (props, ref) => {
   const [isDialogOpen, toggleDialog] = React.useState(false)
-  const [showBanner, toggleBanner] = React.useState(true)
+  const [showBanner, toggleBanner] = React.useState(props.showBanner ?? true)
   const [isCancelling, toggleCancel] = React.useState(false)
+
+  React.useImperativeHandle(ref, (): ConsentManagerApi => ({
+    setPreferences: props.setPreferences,
+    resetPreferences: props.resetPreferences,
+    saveConsent: props.saveConsent,
+  }), [props.setPreferences, props.resetPreferences, props.saveConsent]);
 
   let banner = React.useRef<HTMLElement>(null)
   let preferenceDialog = React.useRef<HTMLElement>(null)
@@ -216,4 +223,4 @@ const Container: React.FC<ContainerProps> = props => {
   )
 }
 
-export default Container
+export default React.forwardRef(Container)

--- a/src/consent-manager/index.tsx
+++ b/src/consent-manager/index.tsx
@@ -24,7 +24,8 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
     bannerSubContent: 'You can change your preferences at any time.',
     bannerBackgroundColor: '#1f4160',
     preferencesDialogTitle: 'Website Data Collection Preferences',
-    cancelDialogTitle: 'Are you sure you want to cancel?'
+    cancelDialogTitle: 'Are you sure you want to cancel?',
+    showBanner: true
   }
 
   render() {
@@ -43,7 +44,9 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
       cancelDialogTitle,
       cancelDialogContent,
       customCategories,
-      onError
+      onError,
+      apiRef,
+      showBanner,
     } = this.props
 
     return (
@@ -69,6 +72,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
         }) => {
           return (
             <Container
+              ref={apiRef}
               customCategories={customCategories}
               destinations={destinations}
               newDestinations={newDestinations}
@@ -91,6 +95,7 @@ export default class ConsentManager extends PureComponent<ConsentManagerProps, {
               preferencesDialogContent={preferencesDialogContent}
               cancelDialogTitle={cancelDialogTitle}
               cancelDialogContent={cancelDialogContent}
+              showBanner={showBanner}
             />
           )
         }}

--- a/src/types.ts
+++ b/src/types.ts
@@ -61,7 +61,14 @@ interface CustomCategory {
   purpose: string
 }
 
+export interface ConsentManagerApi {
+  setPreferences: (newPreferences: CategoryPreferences) => void
+  resetPreferences: () => void
+  saveConsent: (newPreferences?: CategoryPreferences | boolean, shouldReload?: boolean) => void
+}
+
 export interface ConsentManagerProps {
+  apiRef: React.Ref<ConsentManagerApi>
   writeKey: string
   otherWriteKeys?: string[]
   shouldRequireConsent?: () => Promise<boolean> | boolean
@@ -79,4 +86,5 @@ export interface ConsentManagerProps {
   closeBehavior?: CloseBehavior | CloseBehaviorFunction
   initialPreferences?: CategoryPreferences
   customCategories?: CustomCategories
+  showBanner?: boolean
 }


### PR DESCRIPTION
Expose `ConsentManagerApi` via ref prop in `<ConsentManager />` to be able to programmatically control the consent.

Also optionally allow to show/hide the banner.

Usage:

```
const apiRef = useRef<any>();

return (
  <ConsentManager
    apiRef={apiRef}
    showBanner={false}
  />
)
```

`apiRef.current` will be then an object with `setPreferences()`, `resetPreferences()` and `saveConsent()`.